### PR TITLE
fix: register service worker with a relative path

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
   <script>
     // Check that service workers are registered
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js');
+      navigator.serviceWorker.register('./sw.js');
     }
 
     var audio;


### PR DESCRIPTION
If the app is run in a sub folder (like it is now with github pages), then it was pointing to a service worker in the root folder of the domain rather than the current folder of the app (i.e. /grejbox/)

Fixing error message when launching the app:

```
Uncaught (in promise) TypeError: ServiceWorker script at https://mcastagnetti.github.io/sw.js for scope https://mcastagnetti.github.io/ encountered an error during installation.
```

Test:
- Launch the app
- There should be no error message